### PR TITLE
New features, bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,43 @@ While in the body of the macro, `$$` will be bound to the `match-string` and the
 
 An additional local function `$->` permits a generalized access to captured groups.
 
+    ($-> (set &optional (selection :all) (component :capture) (default NIL)))
+
+
+The `set` determines the subset of captured groups to retrieve, always a vector of ``re-capture'' instances, valid options being:
+
+* `:all-groups` selects all groups, named and unnamed
+* `:named-groups` selects named groups only
+* `:unnamed-groups` selects unnamed groups only
+* `group-name` is a string designating the name of the groups to select
+
+The `selection` filters the subset obtained with the `set` parameter, returning either a vector of a single ``re-capture'' object. The argument expects one of these:
+
+* `all` simply returns the existing subset
+* `first` obtains the first group, or the default value upon the subset's dearth of items
+* `last` obtains the last group, or the default value upon the subset's dearth of items
+* `index` constitutes an integer greater or equal to 0 which references the item to select from the subset
+
+As an `re-capture` in its completeness might not be desiderated, the vector or single ``re-capture'' instance(s) might be replaced via the `component` argument:
+
+* `capture` simply returns each `re-capture` instance unmodified
+* `substring` extracts the substring from each `re-capture`
+* `start-position` extracts the start position of the group in the input string
+* `end-position` extracts the end position of the group in the input string
+* `start-and-end-position` extracts the start and end position as a two-item list (start end)
+* `name` extract the group name, which might be `NIL` if an unnamed group
+
+Failure to obtain a group usually returns the `NIL` value. This behavior might be modified by setting a different substitution through the `default` parameter.
+
+    CL-USER > (with-re-match (match (match-re "(!<year>%d{=2,4})/(!<month>%d{[1,2]})/(!<day>%d{=2})" "2018/05/31"))
+                (format T "~&Year:  ~a~%" ($-> "year"  :first :substring))
+                (format T "~&Month: ~a~%" ($-> "month" :first :substring))
+                (format T "~&Day:   ~a~%" ($-> "day"   :first :substring)))
+    Year:  2018
+    Month: 05
+    Day:   31
+
+
 ## Additional Features
 
 In addition to supporting all of what Lua pattern matching has to offer, it also supports branching with `|` and uncaptured groups: `(?..)`. For example...

--- a/README.md
+++ b/README.md
@@ -171,12 +171,12 @@ The `selection` filters the subset obtained with the `set` parameter, returning 
 
 As an `re-capture` in its completeness might not be desiderated, the vector or single ``re-capture'' instance(s) might be replaced via the `component` argument:
 
-* `capture` simply returns each `re-capture` instance unmodified
-* `substring` extracts the substring from each `re-capture`
-* `start-position` extracts the start position of the group in the input string
-* `end-position` extracts the end position of the group in the input string
-* `start-and-end-position` extracts the start and end position as a two-item list (start end)
-* `name` extract the group name, which might be `NIL` if an unnamed group
+* `:capture` simply returns each `re-capture` instance unmodified
+* `:substring` extracts the substring from each `re-capture`
+* `:start-position` extracts the start position of the group in the input string
+* `:end-position` extracts the end position of the group in the input string
+* `:start-and-end-position` extracts the start and end position as a two-item list (start end)
+* `:name` extract the group name, which might be `NIL` if an unnamed group
 
 Failure to obtain a group usually returns the `NIL` value. This behavior might be modified by setting a different substitution through the `default` parameter.
 

--- a/README.md
+++ b/README.md
@@ -170,30 +170,30 @@ An additional local function `$->` permits a generalized access to captured grou
     ($-> (set &optional (selection :all) (component :capture) (default NIL)))
 
 
-The `set` determines the subset of captured groups to retrieve, always a vector of ``re-capture'' instances, valid options being:
+The `set` determines the subset of captured groups to retrieve, always a vector of `re-capture` instances, valid options being:
 
 * `:all-groups` selects all groups, named and unnamed
 * `:named-groups` selects named groups only
 * `:unnamed-groups` selects unnamed groups only
 * `group-name` is a string designating the name of the groups to select
 
-The `selection` filters the subset obtained with the `set` parameter, returning either a vector of a single ``re-capture'' object. The argument expects one of these:
+The `selection` filters the subset obtained with the `set` parameter, returning either a vector of `re-capture`s or a single `re-capture` object. The argument expects one of these values:
 
 * `:all` simply returns the existing subset
 * `:first` obtains the first group, or the default value upon the subset's dearth of items
 * `:last` obtains the last group, or the default value upon the subset's dearth of items
 * `index` constitutes an integer greater or equal to 0 which references the item to select from the subset
 
-As an `re-capture` in its completeness might not be desiderated, the vector or single ``re-capture'' instance(s) might be replaced via the `component` argument:
+As an `re-capture` in its completeness might not be desiderated, the vector or single `re-capture` instance(s) might be replaced via the `component` argument:
 
 * `:capture` simply returns each `re-capture` instance unmodified
 * `:substring` extracts the substring from each `re-capture`
 * `:start-position` extracts the start position of the group in the input string
 * `:end-position` extracts the end position of the group in the input string
 * `:start-and-end-position` extracts the start and end position as a two-item list (start end)
-* `:name` extract the group name, which might be `NIL` if an unnamed group
+* `:name` extracts the group name, which might be `NIL` in the case of an unnamed group
 
-Failure to obtain a group usually returns the `NIL` value. This behavior might be modified by setting a different substitution through the `default` parameter.
+Failure to obtain a group usually results in the `NIL` value. This behavior might be modified by setting a different substitution through the `default` parameter.
 
     CL-USER > (with-re-match (match (match-re "(!<year>%d{=2,4})/(!<month>%d{[1,2]})/(!<day>%d{=2})" "2018/05/31"))
                 (format T "~&Year:  ~a~%" ($-> "year"  :first :substring))
@@ -218,13 +218,11 @@ Finally, the `re` package has one special feature: user-defined character set pr
 
 The predicate must take a single character and return non-nil if the character matches the predicate function. *Note: this is especially handy when parsing unicode strings!*
 
-
-
 ## Ranged Quantifiers
 
-Additional to the quantifiers `?` (zero or one repetitions), `*` (zero or more repetitions), and `+` (one or more repetitions), a “ranged quantifier” is available. This comprises a family of adjustable iteration checkers, by default enclosed within `{` and `}`.
+In addition to the quantifiers `?` (zero or one repetitions), `*` (zero or more repetitions), and `+` (one or more repetitions), a “ranged quantifier” is available. This comprises a family of adjustable iteration checkers, by default enclosed within `{` and `}`.
 
-The family consists of these three variants:
+The family consists of these three variants, each elucidated in a section of its own further below:
 
 | Variant  | Description                                                  |
 | -------- | ------------------------------------------------------------ |
@@ -233,7 +231,7 @@ The family consists of these three variants:
 | `{%:…:`} | A user-defined function to check for desiderated iterations. |
 
 
-### Ranges
+### Range
 
 The instigating brace `{` must be immediately followed by the opening square bracket `[` to form `{[`. Further white spaces are ignored. The complete syntax — albeit variations are extant — is as follows:
 
@@ -247,45 +245,46 @@ Only integer numbers greater or equal to 0, white spaces and omissions are valid
 | `{[*MINIMUM*,]}`             | The number of repetitions must be at least *MINIMUM*, with no maximum required. Hence, *MAXIMUM* defaults to “infinity”. | `{[2,]}` |
 | `{[,*MAXIMUM*]}`             | The number of repetitions must be at most *MAXIMUM*, with no minimum required. Hence, *MINIMUM* defaults to zero. | `{[,10]}` |
 | `{[*REPETITIONS*]}`          | The number of repetitions must exactly equal *REPETITIONS*. This is commensurately equivalent to the syntax `{[*MINIMUM*,*MINIMUM*]}`. | `{[4]}` |
-| `{[,]}`                      | The number of repetitions is unbounded (“infinite”) on both ends. In consectary, this is synonymous to the `*` quantifier. |
+| `{[,]}`                      | The number of repetitions is unbounded (“infinite”) on both ends. In consectary, this is synonymous to the `*` quantifier. | `{[,]}` |
 
 Some examples shall demonstrate these features:
 
-    (match-re "a{[2,4]}b" "aaab")
+    CL-USER > (match-re "a{[2,4]}b" "aaab")
     #<RE-MATCH "aaab">
 
     ;; Too few "a" occurrences.
-    (match-re "a{[2,4]}b" "ab")
+    CL-USER > (match-re "a{[2,4]}b" "ab")
     NIL
 
     ;; Too many "a" occurrences.
-    (match-re "a{[2,4]}b" "aaaaab")
+    CL-USER > (match-re "a{[2,4]}b" "aaaaab")
     NIL
 
-    (match-re "a{[2,]}b" "aaaaaaaaaaaaaaaaab")
+    CL-USER > (match-re "a{[2,]}b" "aaaaaaaaaaaaaaaaab")
     #<RE-MATCH "aaaaaaaaaaaaaaaaab">
 
-    (match-re "a{[,4]}b" "aaaab")
+    CL-USER > (match-re "a{[,4]}b" "aaaab")
     #<RE-MATCH "aaaab">
 
     ;; Too many "a" occurrences.
-    (match-re "a{[,4]}b" "aaaaaaaaaaaaaaaaab")
+    CL-USER > (match-re "a{[,4]}b" "aaaaaaaaaaaaaaaaab")
     NIL
     
-    (match-re "a{[3,3]}b" "aaab")
+    CL-USER > (match-re "a{[3,3]}b" "aaab")
     #<RE-MATCH "aaab">
 
-    (match-re "a{[3]}b" "aaab")
+    CL-USER > (match-re "a{[3]}b" "aaab")
     #<RE-MATCH "aaab">
 
-    (match-re "a{[,]}b" "aaab")
+    CL-USER > (match-re "a{[,]}b" "aaab")
     #<RE-MATCH "aaab">
 
-### Number set
+### Number Sequence
 
-The number of repetitions must equal one of those numbers in the sequence. This sequence is a comma-separated list of integer values greater or equal to zero. Redudant entries are permitted but meaningless. The equal sign must follow immediately after the opening brace to form `{=`, further white spaces are ignored.
+The number of repetitions must equal one of those numbers in the sequence. This sequence is a comma-separated list of integer values greater than or equal to zero. Redudant entries are permitted but meaningless. The equal sign `=` must follow immediately after the opening brace to form `{=`, further white spaces are ignored.
 
 The syntax is:
+
     {= a, b, c, …, d}
 
 Examples:
@@ -303,19 +302,19 @@ The indagation whether the number of repetitions is valid is delegated to a glob
 
     {%:USER-FUNCTION%:}
 
-The signature, in corollary, complies to:
+The function signature, in corollary, complies to:
 
     lambda(number-of-repetitions) => generalized-boolean
 
 Some examples to illustrate:
 
-    (defun even-number-of-repetitions-p (counter)
-      (evenp counter))
-
-    (match-re "a{%:even-number-of-repetitions-p:}b" "aab")
+    CL-USER > (defun even-number-of-repetitions-p (counter)
+                (evenp counter))
+    
+    CL-USER > (match-re "a{%:even-number-of-repetitions-p:}b" "aab")
     #<RE-MATCH "aab">
     
-    (match-re "a{%:even-number-of-repetitions-p:}b" "aaab")
+    CL-USER > (match-re "a{%:even-number-of-repetitions-p:}b" "aaab")
     NIL
 
 
@@ -329,16 +328,45 @@ A few instances of the regular expression engine behavior are adjustable, especi
 * `re-configuration-named-capture-name-ender` designates the character utilized to mark the end of the group name portion of a named captured group, defaulting to `#\>`
 * `re-configuration-permit-ranged-quantifiers`, adjustable with a generalized boolean, determines whether ranged quantifiers of the type `{…}` are recognized at all
 
-An example follows:
+The following example changes the named captured group syntax to `(+[GROUP-NAME])`:
 
-    (setf (re-configuration-named-capture-marker       *re-configuration*) #\+)
-    (setf (re-configuration-named-capture-name-starter *re-configuration*) #\[)
-    (setf (re-configuration-named-capture-name-ender   *re-configuration*) #\])
+    CL-USER > (setf (re-configuration-named-capture-marker       *re-configuration*) #\+)
+    CL-USER > (setf (re-configuration-named-capture-name-starter *re-configuration*) #\[)
+    CL-USER > (setf (re-configuration-named-capture-name-ender   *re-configuration*) #\])
     
-    (with-re-match (match (match-re "(+[year]%d{=2,4})/(+[month]%d{[1,2]})/(+[day]%d{=2})" "2018/05/31"))
-      (format T "~&Year:  ~a~%" ($-> "year"  :first :substring))
-      (format T "~&Month: ~a~%" ($-> "month" :first :substring))
-      (format T "~&Day:   ~a~%" ($-> "day"   :first :substring)))
+    CL-USER > (with-re-match (match (match-re "(+[year]%d{=2,4})/(+[month]%d{[1,2]})/(+[day]%d{=2})" "2018/05/31"))
+                (format T "~&Year:  ~a~%" ($-> "year"  :first :substring))
+                (format T "~&Month: ~a~%" ($-> "month" :first :substring))
+                (format T "~&Day:   ~a~%" ($-> "day"   :first :substring)))
+    Year:  2018
+    Month: 05
+    Day:   31
+
+The `re-configuration-named-capture-name-starter` and `re-configuration-named-capture-name-ender` characters may be equal, here to mandate the delineation `(-"GROUP-NAME")`:
+
+    CL-USER > (setf (re-configuration-named-capture-marker       *re-configuration*) #\-)
+    CL-USER > (setf (re-configuration-named-capture-name-starter *re-configuration*) #\")
+    CL-USER > (setf (re-configuration-named-capture-name-ender   *re-configuration*) #\")
+    
+    CL-USER > (with-re-match (match (match-re "(-\"year\"%d{=2,4})/(-\"month\"%d{[1,2]})/(-\"day\"%d{=2})" "2018/05/31"))
+                (format T "~&Year:  ~a~%" ($-> "year"  :first :substring))
+                (format T "~&Month: ~a~%" ($-> "month" :first :substring))
+                (format T "~&Day:   ~a~%" ($-> "day"   :first :substring)))
+    Year:  2018
+    Month: 05
+    Day:   31
+
+The ranged quantifier deactivated:
+
+    CL-USER > (setf (re-configuration-permit-ranged-quantifiers *re-configuration*) NIL)
+
+    ;; Ranged quantifiers are deactivated. => Literal parsing.
+    CL-USER > (match-re "a{[1,7]}b" "aaab")
+    NIL
+
+    ;; Ranged quantifiers are deactivated. => Literal parsing.
+    CL-USER > (match-re "a{[1,7]}b" "a{1}b")
+    #<RE-MATCH "a{1}b">
 
 
 # Thank You!

--- a/README.md
+++ b/README.md
@@ -247,7 +247,39 @@ Only integer numbers greater or equal to 0, white spaces and omissions are valid
 | `{[*MINIMUM*,]}`             | The number of repetitions must be at least *MINIMUM*, with no maximum required. Hence, *MAXIMUM* defaults to “infinity”. | `{[2,]}` |
 | `{[,*MAXIMUM*]}`             | The number of repetitions must be at most *MAXIMUM*, with no minimum required. Hence, *MINIMUM* defaults to zero. | `{[,10]}` |
 | `{[*REPETITIONS*]}`          | The number of repetitions must exactly equal *REPETITIONS*. This is commensurately equivalent to the syntax `{[*MINIMUM*,*MINIMUM*]}`. | `{[4]}` |
+| `{[,]}`                      | The number of repetitions is unbounded (“infinite”) on both ends. In consectary, this is synonymous to the `*` quantifier. |
 
+Some examples shall demonstrate these features:
+
+    (match-re "a{[2,4]}b" "aaab")
+    #<RE-MATCH "aaab">
+
+    ;; Too few "a" occurrences.
+    (match-re "a{[2,4]}b" "ab")
+    NIL
+
+    ;; Too many "a" occurrences.
+    (match-re "a{[2,4]}b" "aaaaab")
+    NIL
+
+    (match-re "a{[2,]}b" "aaaaaaaaaaaaaaaaab")
+    #<RE-MATCH "aaaaaaaaaaaaaaaaab">
+
+    (match-re "a{[,4]}b" "aaaab")
+    #<RE-MATCH "aaaab">
+
+    ;; Too many "a" occurrences.
+    (match-re "a{[,4]}b" "aaaaaaaaaaaaaaaaab")
+    NIL
+    
+    (match-re "a{[3,3]}b" "aaab")
+    #<RE-MATCH "aaab">
+
+    (match-re "a{[3]}b" "aaab")
+    #<RE-MATCH "aaab">
+
+    (match-re "a{[,]}b" "aaab")
+    #<RE-MATCH "aaab">
 
 ### Number set
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,24 @@ Once you have successfully matched and have a `re-match` object, you can use the
 
 * `match-string` returns the entire match
 * `match-groups` returns a list of groups
-* `match-captures` returns a vector of extended captured groups, comprising substring, optional name, start index, and end index
+* `match-captures` returns a vector of extended captured groups, each an instance of the `re-capture` class, comprising substring, optional name, start index, and end index
 * `match-pos-start` returns the index where the match began
 * `match-pos-end` returns the index where the match ended
+
+Further functions exists specialized on the captured groups retrieval:
+
+* `match-capture-at-index` returns the group at the given index
+* `match-captures-by-name` returns a vector of named captured groups with the given name
+* `match-capture-by-name` returns either the first or the last named captured group with the given name
+* `match-capture-by-name-at-index` returns the `index`-th named captured group
+* `match-has-capture-of-name` return `T` if at least one named captured group with the given name exists, otherwise `NIL`
+* `match-extract-data` procures a generalized access to the captured groups and their data
+
+The `re-capture` class offers following reader functions:
+* `re-capture-substring` returns the substring of the input string enclosed in the group
+* `re-capture-start-position` returns the start position of the captured group in the input string
+* `re-capture-end-position` returns the end position of the captured group in the input string
+* `re-capture-name` returns the name of the named captured group, or `NIL` if the group is unnamed
 
 Try peeking into a match...
 
@@ -202,6 +217,16 @@ Finally, the `re` package has one special feature: user-defined character set pr
     #<RE-MATCH "103">
 
 The predicate must take a single character and return non-nil if the character matches the predicate function. *Note: this is especially handy when parsing unicode strings!*
+
+## Regular Engine Configuration
+
+A few instances of the regular expression engine behavior are adjustable, especially with the purpose of counteracting against undesired reservation of common characters like `{`, `}`, and `!` by the engine's features, and to retain compatibility with previous versions of the `re` library. The configurating entity is the class `re-configuration`, whose global instance `*re-configuration*` can be queried and modified by the following accessor functions:
+
+* `re-configuration-permit-named-captures`, adjustable with a generalized boolean, determines whether named captured groups are recognized at all (`T`) or not (`NIL`)
+* `re-configuration-named-capture-marker` designates the character utilized to distinguish an unnamed or ignored group from a named one, defaulting to `#\!`
+* `re-configuration-named-capture-name-starter` designates the character utilized to start the group name portion of a named captured group, defaulting to `#\<`
+* `re-configuration-named-capture-name-ender` designates the character utilized to mark the end of the group name portion of a named captured group, defaulting to `#\>`
+* `re-configuration-permit-ranged-quantifiers`, adjustable with a generalized boolean, determines whether ranged quantifiers of the type `{…}` are recognized at all
 
 # Thank You!
 

--- a/README.md
+++ b/README.md
@@ -115,14 +115,14 @@ As an `re-capture` in its completeness might not be desiderated, the vector or s
 
 Failure to obtain a group usually results in the `NIL` value. This behavior might be modified by setting a different substitution through the `default` parameter.
 
-    CL-USER > (let ((m (match-re "(?(bunny|cat|dog)|(carrot|milk|tuna)*%s+)*"
+    CL-USER > (let ((m (match-re "(?(bunny|cat|dog)|(!<food>carrot|milk|tuna)*%s+)*"
                        "cat milk bunny tuna carrot dog bunny")))
                 (format T "~&Group names:     ~a~%" (match-extract-data m :component :name))
                 (format T "~&Substrings:      ~a~%" (match-extract-data m :component :substring))
                 (format T "~&Starts:          ~a~%" (match-extract-data m :component :start-position))
                 (format T "~&Ends:            ~a~%" (match-extract-data m :component :end-position))
                 (format T "~&Starts and ends: ~a~%" (match-extract-data m :component :start-and-end-position)))
-    Group names:     #(NIL NIL NIL NIL NIL NIL NIL)
+    Group names:     #(NIL food NIL food food NIL NIL)
     Substrings:      #(cat milk bunny tuna carrot dog bunny)
     Starts:          #(0 4 9 15 20 27 31)
     Ends:            #(3 8 14 19 26 30 36)

--- a/README.md
+++ b/README.md
@@ -86,7 +86,34 @@ Let us match a pattern and access one of its captured groups:
     Start:      0
     End:        3
 
-The `match-extract-data` function offers some convenience in operating upon matches and their captures:
+The `match-extract-data` function offers some convenience in operating upon matches and their captures.
+
+    (match-extract-data (&key (set :all-groups) (selection :all) (component :capture) (default NIL)))
+
+The `set` determines the subset of captured groups to retrieve, always a vector of `re-capture` instances, valid options being:
+
+* `:all-groups` selects all groups, named and unnamed
+* `:named-groups` selects named groups only
+* `:unnamed-groups` selects unnamed groups only
+* `group-name` is a string designating the name of the groups to select
+
+The `selection` filters the subset obtained with the `set` parameter, returning either a vector of `re-capture`s or a single `re-capture` object. The argument expects one of these values:
+
+* `:all` simply returns the existing subset
+* `:first` obtains the first group, or the default value upon the subset's dearth of items
+* `:last` obtains the last group, or the default value upon the subset's dearth of items
+* `index` constitutes an integer greater or equal to 0 which references the item to select from the subset
+
+As an `re-capture` in its completeness might not be desiderated, the vector or single `re-capture` instance(s) might be replaced via the `component` argument:
+
+* `:capture` simply returns each `re-capture` instance unmodified
+* `:substring` extracts the substring from each `re-capture`
+* `:start-position` extracts the start position of the group in the input string
+* `:end-position` extracts the end position of the group in the input string
+* `:start-and-end-position` extracts the start and end position as a two-item list `(start end)`
+* `:name` extracts the group name, which might be `NIL` in the case of an unnamed group
+
+Failure to obtain a group usually results in the `NIL` value. This behavior might be modified by setting a different substitution through the `default` parameter.
 
     CL-USER > (let ((m (match-re "(?(bunny|cat|dog)|(carrot|milk|tuna)*%s+)*"
                        "cat milk bunny tuna carrot dog bunny")))
@@ -278,31 +305,7 @@ An additional local function `$->` permits a generalized access to captured grou
 
     ($-> (set &optional (selection :all) (component :capture) (default NIL)))
 
-
-The `set` determines the subset of captured groups to retrieve, always a vector of `re-capture` instances, valid options being:
-
-* `:all-groups` selects all groups, named and unnamed
-* `:named-groups` selects named groups only
-* `:unnamed-groups` selects unnamed groups only
-* `group-name` is a string designating the name of the groups to select
-
-The `selection` filters the subset obtained with the `set` parameter, returning either a vector of `re-capture`s or a single `re-capture` object. The argument expects one of these values:
-
-* `:all` simply returns the existing subset
-* `:first` obtains the first group, or the default value upon the subset's dearth of items
-* `:last` obtains the last group, or the default value upon the subset's dearth of items
-* `index` constitutes an integer greater or equal to 0 which references the item to select from the subset
-
-As an `re-capture` in its completeness might not be desiderated, the vector or single `re-capture` instance(s) might be replaced via the `component` argument:
-
-* `:capture` simply returns each `re-capture` instance unmodified
-* `:substring` extracts the substring from each `re-capture`
-* `:start-position` extracts the start position of the group in the input string
-* `:end-position` extracts the end position of the group in the input string
-* `:start-and-end-position` extracts the start and end position as a two-item list (start end)
-* `:name` extracts the group name, which might be `NIL` in the case of an unnamed group
-
-Failure to obtain a group usually results in the `NIL` value. This behavior might be modified by setting a different substitution through the `default` parameter.
+The capabilities of this function match that of `match-extract-data`, solely substituting keyword parameters for mandatory or optional ones for conciseness.
 
     CL-USER > (with-re-match (match (match-re "(!<year>%d{=2,4})/(!<month>%d{[1,2]})/(!<day>%d{=2})" "2018/05/31"))
                 (format T "~&Year:  ~a~%" ($-> "year"  :first :substring))

--- a/README.md
+++ b/README.md
@@ -164,9 +164,9 @@ The `set` determines the subset of captured groups to retrieve, always a vector 
 
 The `selection` filters the subset obtained with the `set` parameter, returning either a vector of a single ``re-capture'' object. The argument expects one of these:
 
-* `all` simply returns the existing subset
-* `first` obtains the first group, or the default value upon the subset's dearth of items
-* `last` obtains the last group, or the default value upon the subset's dearth of items
+* `:all` simply returns the existing subset
+* `:first` obtains the first group, or the default value upon the subset's dearth of items
+* `:last` obtains the last group, or the default value upon the subset's dearth of items
 * `index` constitutes an integer greater or equal to 0 which references the item to select from the subset
 
 As an `re-capture` in its completeness might not be desiderated, the vector or single ``re-capture'' instance(s) might be replaced via the `component` argument:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It makes heavy use of the monadic [`parse`](http://github.com/massung/parse) com
 
 ## Compiling Patterns
 
-To create a `re` object, you can either use the `compile-re` function or the `#r` dispatch macro.
+To create an `re` object, you can either use the `compile-re` function or the `#r` dispatch macro.
 
     CL-USER > (compile-re "%d+")
     #<RE "%d+">
@@ -410,9 +410,9 @@ Examples:
 
 ### User-defined Function
 
-The indagation whether the number of repetitions is valid is delegated to a global function *USER-FUNCTION*, the same must accept exactly one argument, the current number of iterations, and return a generalized boolean being `T` if the iterations are valid, and `NIL` upon invalidity. The syntax is:
+The indagation whether the number of repetitions is valid is delegated to a global function *USER-FUNCTION*, the same must accept exactly one argument, the current number of iterations, and return a generalized boolean being `T` if the iterations are valid, and `NIL` upon invalidity. The percent sign `%` must follow the opening brace `{` immediately to form `{%`. The syntax is:
 
-    {%:USER-FUNCTION%:}
+    {%:USER-FUNCTION:}
 
 The function signature, in corollary, complies to:
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Once you have successfully matched and have a `re-match` object, you can use the
 
 * `match-string` returns the entire match
 * `match-groups` returns a list of groups
+* `match-captures` returns a vector of extended captured groups, comprising substring, optional name, start index, and end index
 * `match-pos-start` returns the index where the match began
 * `match-pos-end` returns the index where the match ended
 
@@ -116,9 +117,22 @@ Captures can be nested, but are always returned in the order they are **opened**
 
 *HINT: you can always use the `match-string` function to get at the full text that was matched and there's no need to capture the entire pattern.*
 
+## Named Groups
+
+An extended method of addressing captured groups, or simply “captures”, constitutes the definition of named captured groups. These are based upon the parentheses syntax of ordinary captured groups, with the opening parenthesis being followed by the “!” marker to designate the named variant. The basic syntax adheres to: `(!<GROUP-NAME>)`, with the `GROUP-NAME`, enclosed between the markers `<` and `>` being any character string — even white spaces — apart from the `>` group name end determinator.
+
+    CL-USER > (match-captures (match-re "(!<number>%d+)" "123abc"))
+    #(#<re-capture start=0, end=3, substring="123", name=number>)
+
+These names are not confined to uniqueness, acting in some sense as “tags”: An arbitrary number of named captured groups with the same denomination may be defined. The following example retrieves four named captures, each with the name “letter”:
+
+    CL-USER > (match-captures (match-re "(!<letter>%a)+" "abcd"))
+    #(#<re-capture start=0, end=1, substring="a", name=letter> #<re-capture start=1, end=2, substring="b", name=letter> #<re-capture start=2, end=3, substring="c", name=letter> #<re-capture start=3, end=4, substring="d", name=letter>)
+
+
 ## The `with-re-match` Macro
 
-Whe `with-re-match` macro can be used to assist in extracting the matched patterns and groups.
+The `with-re-match` macro can be used to assist in extracting the matched patterns and groups.
 
     (with-re-match ((var match-expr &key no-match) &body body)
 
@@ -135,6 +149,8 @@ While in the body of the macro, `$$` will be bound to the `match-string` and the
                          (format nil "~@(~a~)." $1))))
                 (replace-re #r/(%a)%a+%s*/ #'initial "lisp in small pieces" :all t))
     "L.I.S.P."
+
+An additional local function `$->` permits a generalized access to captured groups.
 
 ## Additional Features
 

--- a/re.lisp
+++ b/re.lisp
@@ -618,9 +618,9 @@
 
                    ;; groups
                    ;; Possible return values are:
-                   ;;   captured   group: (:group (list :captured))
-                   ;;   uncaptured group: (:group (list :uncaptured #\?))
-                   ;;   named      group: (:group (list :named      "?<NAMESTRING>"))
+                   ;;   captured   group: (:group (list :captured   #\( stream))
+                   ;;   uncaptured group: (:group (list :uncaptured #\( stream))
+                   ;;   named      group: (:group (list :named      #\( stream))
                    (#\( (with-slots (permit-named-captures named-capture-marker)
                                     *re-configuration*
                           (cond

--- a/re.lisp
+++ b/re.lisp
@@ -33,10 +33,139 @@
    ;; match readers
    #:match-string
    #:match-groups
+   #:match-captures
    #:match-pos-start
-   #:match-pos-end))
+   #:match-pos-end
+   
+   ;; capturing groups retrieval
+   #:match-capture-at-index
+   #:match-captures-by-name
+   #:match-capture-by-name
+   #:match-capture-by-name-at-index
+   #:match-has-capture-of-name
+   
+   ;; convenience functions
+   #:match-extract-data
+   
+   ;; capturing group definition
+   #:re-capture
+   #:re-capture-start-position
+   #:re-capture-end-position
+   #:re-capture-substring
+   #:re-capture-name
+   #:re-capture-has-name
+   
+   ;; regular expression configurations
+   #:re-configuration
+   #:re-configuration-permit-named-captures
+   #:re-configuration-named-capture-marker
+   #:re-configuration-named-capture-name-starter
+   #:re-configuration-named-capture-name-ender
+   #:re-configuration-permit-ranged-quantifiers
+   #:*re-configuration*
+   ))
 
 (in-package :re)
+
+
+
+
+(defclass re-configuration ()
+  (
+   ;; Options for NAMED CAPTURING GROUPS:
+   (permit-named-captures
+     :initarg       :permit-named-captures
+     :initform      NIL
+     :accessor      re-configuration-permit-named-captures
+     :documentation "Recognize named captures at all?")
+   (named-capture-marker
+     :initarg       :named-capture-marker
+     :initform      #\!
+     :accessor      re-configuration-named-capture-marker
+     :type          character
+     :documentation "Character to introduce a named capture, that is,
+                     distinguish it from an unnamed or uncaptured group.
+                     Example: #\! in (!<...>).")
+   (named-capture-name-starter
+     :initarg       :named-capture-name-starter
+     :initform      #\<
+     :accessor      re-configuration-named-capture-name-starter
+     :type          character
+     :documentation "Character to designate the start of a named
+                     capture's name portion.
+                     Example: #\< in (!<NAME>).")
+   (named-capture-name-ender
+     :initarg       :named-capture-name-ender
+     :initform      #\>
+     :accessor      re-configuration-named-capture-name-ender
+     :type          character
+     :documentation "Character to designate the end of a named
+                     capture's name portion.
+                     Example: #\> in (!<NAME>).")
+   
+   ;; Options for RANGED QUANTIFIERS:
+   (permit-ranged-quantifiers
+     :initarg       :permit-ranged-quantifiers
+     :initform      NIL
+     :accessor      re-configuration-permit-ranged-quantifiers
+     :documentation "Are ranged quantifiers of the type '{...}'
+                     homologated?"))
+  (:documentation "Bundles the options for the regular expression engine."))
+
+;;; ----------------------------------------------------
+
+(defparameter *re-configuration*
+  (make-instance 're-configuration
+    :permit-named-captures      T
+    :named-capture-marker       #\!
+    :named-capture-name-starter #\<
+    :named-capture-name-ender   #\>
+    :permit-ranged-quantifiers  T))
+
+;;; ----------------------------------------------------
+
+(defclass re-capture ()
+  ((start-position
+     :initarg       :start-position
+     :initform      0
+     :type          integer
+     :reader        re-capture-start-position
+     :documentation "The start position of this capturing group
+                     in the input string.")
+   (end-position
+     :initarg       :end-position
+     :initform      0
+     :type          integer
+     :reader        re-capture-end-position
+     :documentation "The end position of this capturing group
+                     in the input string.")
+   (substring
+     :initarg       :substring
+     :initform      ""
+     :type          string
+     :reader        re-capture-substring
+     :documentation "The substring demarcated by this capturing group.")
+   (name
+     :initarg       :name
+     :initform      NIL
+     :type          (or null string)
+     :reader        re-capture-name
+     :documentation "The optional name of the capturing group."))
+  (:documentation "Represents a capturing group, either named
+                   or unnamed."))
+
+(defmethod print-object ((group re-capture) stream)
+  (with-slots (start-position end-position substring name) group
+    (format stream "#<re-capture start=~a, end=~a, substring=~s, name=~a>"
+      start-position
+      end-position
+      substring
+      name)))
+
+(defun re-capture-has-name (capturing-group)
+  "Checks whether the CAPTURING-GROUP has a name."
+  (with-slots (name) capturing-group
+    (not (null name))))
 
 ;;; ----------------------------------------------------
 
@@ -50,9 +179,113 @@
 (defclass re-match ()
   ((match     :initarg :match      :reader match-string)
    (groups    :initarg :groups     :reader match-groups)
+   ;; Vector of "re-capture" instances.
+   (captures  :initarg :captures   :reader match-captures)
+   ;; Hash-Table: group-name -> vector of group-indices.
+   (name-map  :initarg :name-map   :reader match-name-map)
    (start-pos :initarg :start-pos  :reader match-pos-start)
    (end-pos   :initarg :end-pos    :reader match-pos-end))
   (:documentation "Matched pattern."))
+
+;;; ----------------------------------------------------
+
+;; Public.
+(defun match-capture-at-index (match index &key (default NIL))
+  "Returns the group of the MATCH at the given INDEX, or, if the
+   INDEX is invalid, the DEFAULT value."
+  (with-slots (captures) match
+    (if (array-in-bounds-p captures index)
+      (aref captures index)
+      default)))
+
+;;; ----------------------------------------------------
+
+;; Private.
+(defun get-captures-by-name (match group-name)
+  "Returns a vector of re-capture instances representing those
+   groups in the MATCH associated with the GROUP-NAME.
+   The vector is empty if no such group could be detected."
+  (with-slots (name-map captures) match
+    (let ((group-indices (gethash group-name name-map)))
+      (if group-indices
+        (let ((captures-for-indices (make-array (length group-indices)
+                                                :adjustable T
+                                                :fill-pointer 0)))
+          (loop
+            for group-index      across group-indices
+            for capture-at-index =      (aref captures group-index)
+            do  (vector-push-extend capture-at-index captures-for-indices))
+          captures-for-indices)
+        (make-array 0)))))
+
+;;; ----------------------------------------------------
+
+;; Private.
+(defun get-capture-by-name-at-index (match group-name index
+                                     &optional (default-value NIL has-default-value))
+  "Returns the INDEX-th ``re-capture'' with the GROUP-NAME in the MATCH.
+   If either the GROUP-NAME is unknown or the INDEX is invalid, and a
+   DEFAULT-VALUE is supplied, this substitute value will be returned,
+   otherwise an error is triggered to signal a failure."
+  (declare (ignorable default-value has-default-value))
+  (let ((captures-by-name (get-captures-by-name match group-name)))
+    (if (< index (length captures-by-name))
+      (aref captures-by-name index)
+      (if has-default-value
+        default-value
+        (error "Invalid index for capture: ~d." index)))))
+
+;;; ----------------------------------------------------
+
+;; Public.
+(defun match-captures-by-name (match group-name)
+  "Returns a vector containing all capturing groups of the MATCH
+   designated by the GROUP-NAME."
+  (get-captures-by-name match group-name))
+
+;;; ----------------------------------------------------
+
+;; Public.
+(defun match-capture-by-name (match group-name
+                              &key (selection :first)
+                                   (default    NIL))
+  "Returns the capturing group of the MATCH designated by the
+   GROUP-NAME, if such exists, and the SELECTION.
+   The SELECTION might appopriate one of these two values:
+     - The symbol :first, to obtain the first group with such name.
+     - The symbol :last,  to obtain the last  group with such name.
+   If no capturing group with this label can be found: returns NIL.
+   This function constitutes a convenient alernative to
+   MATCH-CAPTURE-BY-NAME-AT-INDEX, aimed as simulating the
+   condition of capturing group names being unique."
+  (let* ((captures-by-name   (get-captures-by-name match group-name))
+         (number-of-captures (length captures-by-name))
+         (has-captures       (plusp  number-of-captures)))
+    (if has-captures
+      (case selection
+        (:first    (aref captures-by-name 0))
+        (:last     (aref captures-by-name (1- number-of-captures)))
+        (otherwise (error "Invalid SELECTION: ~a." selection)))
+      default)))
+
+;;; ----------------------------------------------------
+
+;; Public.
+(defun match-capture-by-name-at-index (match group-name index)
+  "Returns the INDEX-th capturing group of the MATCH designated by the
+   GROUP-NAME, if such exists.
+   If no capturing group with this label can be found: returns NIL.
+   If the INDEX is invalid:                            returns NIL."
+  (get-capture-by-name-at-index match group-name index))
+
+;;; ----------------------------------------------------
+
+;; Public.
+(defun match-has-capture-of-name (match group-name)
+  "Checks whether the MATCH encompasses at least one capture designated
+   by the GROUP-NAME."
+  (let ((captures-of-name (get-captures-by-name match group-name)))
+    (and captures-of-name (plusp (length captures-of-name)))))
 
 ;;; ----------------------------------------------------
 
@@ -125,17 +358,25 @@
                 're-group))
 
     ;; check to see if there is a following iteration token
-    (.opt e (.or (.do (.is :*) (.ret (list :* e)))
-                 (.do (.is :-) (.ret (list :- e)))
-                 (.do (.is :+) (.ret (list :+ e)))
-                 (.do (.is :?) (.ret (list :? e)))))))
+    (.opt e (.or (.do (.is :*)     (.ret (list :*     e)))
+                 (.do (.is :-)     (.ret (list :-     e)))
+                 (.do (.is :+)     (.ret (list :+     e)))
+                 (.do (.is :?)     (.ret (list :?     e)))
+                 
+                 ;; The ranged quantifier additionally requires the
+                 ;; portion enclosed between its markers "{" and "}"
+                 ;; (here: stored in the variable "x").
+                 (.let (x (.is :start-range))
+                   (let ((range-string (read-range-from-stream x)))
+                     (.do (.is :end-range)
+                       (.ret (list :range e range-string)))))))))
 
 ;;; ----------------------------------------------------
 
 (define-parser re-boundary
   "The start or end of a string."
   (.or (.do (.is :start) (.ret (list :start)))
-       (.do (.is :end) (.ret (list :end)))))
+       (.do (.is :end)   (.ret (list :end)))))
 
 ;;; ----------------------------------------------------
 
@@ -151,7 +392,7 @@
   (.or (.do (.is :any) (.ret '(:any)))
 
        ;; predicates and exact characters
-       (.let (p (.is :is)) (.ret (list :is p)))
+       (.let (p (.is :is))   (.ret (list :is   p)))
        (.let (c (.is :char)) (.ret (list :char c)))))
 
 ;;; ----------------------------------------------------
@@ -188,23 +429,110 @@
   (.or (.is :char)
 
        ;; special characters are aren't special in a set
-       (.do (.is :any) (.ret #\.))
-       (.do (.is :or) (.ret #\|))
-       (.do (.is :*) (.ret #\*))
-       (.do (.is :-) (.ret #\-))
-       (.do (.is :+) (.ret #\+))
-       (.do (.is :?) (.ret #\?))
-       (.do (.is :group) (.ret #\())
-       (.do (.is :end-group) (.ret #\)))))
+       (.do (.is :any)         (.ret #\.))
+       (.do (.is :or)          (.ret #\|))
+       (.do (.is :*)           (.ret #\*))
+       (.do (.is :-)           (.ret #\-))
+       (.do (.is :+)           (.ret #\+))
+       (.do (.is :?)           (.ret #\?))
+       (.do (.is :group)       (.ret #\())
+       (.do (.is :end-group)   (.ret #\)))
+       (.do (.is :start-range) (.ret #\{))
+       (.do (.is :end-range)   (.ret #\}))))
+
+;;; ----------------------------------------------------
+
+(defun read-captured-group-name (stream)
+  "Read the name of a captured group from an input STREAM.
+   The STREAM is expected to point to the captured group start character
+   (usually #\<) and contain the captured group end character
+   (usually \#>).
+     The function returns a string between those two
+   demarcating characters, for example: The stream encompassing
+   \"<year>...\" will return the string \"year\".
+     As a side effect, the STREAM will be modified to point to the next
+   character after the captured group start character."
+  (let ((token-value (make-array 0 :element-type 'character
+                                   :adjustable    t
+                                   :fill-pointer  0)))
+    ;; Read the named captured group start character (usually #\<)
+    ;; before iterating.
+    ;; => Otherwise: Problems if start and end characters are equal.
+    ;; 
+    ;; NOTE:
+    ;;   Currently the storage and indagation of the first stream
+    ;;   character is otiose, as no alternative cases exist other than
+    ;;   the start of a named captured group's name. But this might
+    ;;   change in the future, for instance, to provide further
+    ;;   configurations. In consectary, a checking is performed.
+    (with-slots (named-capture-name-starter named-capture-name-ender)
+                *re-configuration*
+      (let ((name-section-id (read-char stream)))
+        (unless (char-equal name-section-id named-capture-name-starter)
+          (error "Expected the named captured group name start character ~s, but found ~s."
+            named-capture-name-starter
+            name-section-id)))
+      (loop
+        for   next-char = (read-char stream)
+        while next-char
+        ;; The next character will demarcate the end of the
+        ;; captured group name (usually #\>)?
+        ;; => Read it to clean the stream, but do not store it.
+        do    (if (char-equal next-char named-capture-name-ender)
+                (return)
+                (vector-push-extend next-char token-value))))
+    token-value))
 
 ;;; ----------------------------------------------------
 
 (define-parser re-group
   "Match an optionally captured group."
-  (.let* ((ignorep (.is :group))
-          (xs 're-parser))
-    (.do (.is :end-group)
-         (.ret (list (if ignorep :ignore :capture) xs)))))
+  (.let (group-data (.is :group))
+    (let ((group-type (first group-data)))
+      (case group-type
+        ;; Uncaptured group? => Remove the "?" designator from the stream.
+        (:uncaptured (let ((stream (third group-data)))
+                       (read-char stream)
+                       (.let (xs 're-parser)
+                         (.do (.is :end-group)
+                           (.ret (list :ignore xs NIL))))))
+        
+        (:captured   (.let (xs 're-parser)
+                       (.do (.is :end-group)
+                         (.ret (list :capture xs NIL)))))
+        
+        ;; Named group? => Remove the "!" designator from the stream.
+        (:named      (let ((stream (third group-data)))
+                       (read-char stream)
+                       (let ((group-name (read-captured-group-name stream)))
+                         (.let (xs 're-parser)
+                           (.do (.is :end-group)
+                             (.ret (list :capture xs group-name)))))))
+        
+        (otherwise   (.fail "Invalid GROUP-TYPE: ~s." group-type))))))
+
+;;; ----------------------------------------------------
+
+;; Checks whether the next character in the STREAM equals the
+;; CHARACTER-TO-MATCH-AGAINST. The STREAM will not be modified.
+(defun next-character-equals (stream character-to-match-against)
+  (eq (peek-char nil stream nil nil) character-to-match-against))
+
+;;; ----------------------------------------------------
+
+;; Reads a range as a string from the STREAM, expected in the pattern
+;;   <any-characters>}
+;; The returned string value is of the pattern
+;;   MINIMUM,MAXIMUM
+;; The STREAM will be modified by reading from it.
+(defun read-range-from-stream (stream)
+  (with-output-to-string (range-string)
+    (loop
+      while (not (next-character-equals stream #\}))
+      for next-char = (read-char stream)
+      do  (write-char next-char range-string)
+          (when (next-character-equals stream #\})
+            (return)))))
 
 ;;; ----------------------------------------------------
 
@@ -289,10 +617,39 @@
                    (#\| :or)
 
                    ;; groups
-                   (#\( (if (eql (peek-char nil stream nil nil) #\?)
-                            (values :group (read-char stream))
-                          (values :group ())))
-
+                   ;; Possible return values are:
+                   ;;   captured   group: (:group (list :captured))
+                   ;;   uncaptured group: (:group (list :uncaptured #\?))
+                   ;;   named      group: (:group (list :named      "?<NAMESTRING>"))
+                   (#\( (with-slots (permit-named-captures named-capture-marker)
+                                    *re-configuration*
+                          (cond
+                            ;; Uncaptured group?
+                            ((next-character-equals stream #\?)
+                             (values :group (list :uncaptured  #\( stream)))
+                            ;; Potential named captured group?
+                            ((next-character-equals stream named-capture-marker)
+                             (if permit-named-captures
+                               (values :group (list :named    #\( stream))
+                               (values :group (list :captured #\( stream))))
+                            ;; Unnamed captured group?
+                            (t
+                             (values :group (list :captured    #\( stream))))))
+                   
+                   ;; ranged iterator
+                   (#\{ (with-slots (permit-ranged-quantifiers)
+                                    *re-configuration*
+                          (if permit-ranged-quantifiers
+                            (values :start-range stream)
+                            (values :char        #\{))))
+                   
+                   ;; end of ranged iterator
+                   (#\} (with-slots (permit-ranged-quantifiers)
+                                    *re-configuration*
+                          (if permit-ranged-quantifiers
+                            (values :end-range)
+                            (values :char      #\}))))
+                   
                    ;; sets
                    (#\[ (if (eql (peek-char nil stream nil nil) #\^)
                             (values :set (read-char stream))
@@ -317,6 +674,201 @@
 
       ;; parse all the tokens in the regular expression
       (parse 're-parser #'token-reader))))
+
+;;; ----------------------------------------------------
+
+(defun is-bound-negative (bound)
+  "Checks whether the number BOUND is negative.
+   Returns:
+     T   - if the BOUND is not NIL and is a negative number
+     NIL - if the BOUND is NIL or if it is a positive number."
+  (and bound (minusp bound)))
+
+;;; ----------------------------------------------------
+
+(defun check-range-minimum (minimum)
+  (when (is-bound-negative minimum)
+    (error "The range minimum must be >= 0: ~a is negative." minimum)))
+
+;;; ----------------------------------------------------
+
+(defun check-range-maximum (maximum)
+  (when (is-bound-negative maximum)
+    (error "The range maximum must be >= 0: ~a is negative." maximum)))
+
+;;; ----------------------------------------------------
+
+(defun check-range-bounds (range)
+  "Checks whether the minimum and maximum of the RANGE are valid,
+   that is, if both bounds are non-NIL, the minimum must be less than
+   or equal to the maximum.
+   Upon breach of this condition, an error is triggered."
+  (destructuring-bind (minimum maximum) range
+    (when (and minimum maximum)
+      (when (> minimum maximum)
+        (error "The range minimum must be less than or ~
+                equal to the range maximum: ~a > ~a."
+                minimum maximum)))))
+
+;;; ----------------------------------------------------
+
+(defun parse-range-minimum (range-string)
+  "Parses a RANGE-STRING's minimum, returning two values:
+     (1) the lower bound of the range, either an integer number or NIL
+     (2) the rest of the RANGE-STRING following the minimum portion."
+  (let* ((end-position-of-minimum (or (position #\, range-string)
+                                      (length       range-string)))
+         (minimum-as-string (subseq range-string 0 end-position-of-minimum))
+         (rest-of-range     (subseq range-string end-position-of-minimum)))
+    (setf minimum-as-string (string-trim "" minimum-as-string))
+    (if (plusp (length minimum-as-string))
+      (values (parse-integer minimum-as-string) rest-of-range)
+      (values NIL                               rest-of-range))))
+
+;;; ----------------------------------------------------
+
+(defun parse-range-maximum (range-string minimum)
+  "Parses the RANGE-STRING's maximum, returning two values:
+     (1) the upper bound of the range, either an integer number or NIL
+     (2) the rest of the RANGE-STRING following the maximum portion."
+  (let ((maximum NIL))
+    (setf range-string (string-trim " " range-string))
+    (cond
+      ;; Empty string without comma? => No maximum. => Reuse MINIMUM.
+      ((zerop (length range-string))
+        (setf maximum minimum))
+      ;; Not an empty string?
+      (T
+        ;; Remove preceding comma (",").
+        (setf range-string (string-trim " ," range-string))
+        ;; Parse the maximum. It may be become NIL.
+        (setf maximum (parse-integer range-string :junk-allowed T))))
+    (values maximum range-string)))
+
+;;; ----------------------------------------------------
+
+(defun parse-range (range-string)
+  "Parses the RANGE-STRING of the pattern
+     [minimum, maximum]
+   returning a list of two values:
+     (minimum maximum)
+   either of these items may be NIL."
+  (let ((minimum NIL)
+        (maximum NIL)
+        (range   NIL))
+    (setf range-string (string-trim "[]" range-string))
+    ;; Extract the MINIMUM.
+    (multiple-value-bind (extracted-minimum curtailed-range-string)
+                         (parse-range-minimum range-string)
+      (setf minimum      extracted-minimum)
+      (setf range-string curtailed-range-string)
+      (check-range-minimum minimum))
+    ;; Extract the MAXIMUM.
+    (multiple-value-bind (extracted-maximum curtailed-range-string)
+                         (parse-range-maximum range-string minimum)
+      (declare (ignore curtailed-range-string))
+      (setf maximum      extracted-maximum)
+      (check-range-maximum maximum))
+    ;; Generate and check the RANGE.
+    (setf range (list minimum maximum))
+    (check-range-bounds range)
+    range))
+
+;;; ----------------------------------------------------
+
+(defun are-iterations-in-range (range iterations)
+  "Checks whether the ITERATIONS are in the RANGE, that is,
+   the numeric value of ITERATIONS is greater than or equal to the
+   RANGE minimum and less than or equal to the RANGE maximum.
+   Any of the two bounds being NIL is construed as a ``infinity''."
+  (let ((is-in-lower-bound NIL)
+        (is-in-upper-bound NIL))
+    (destructuring-bind (minimum maximum) range
+      (if minimum
+        (setf is-in-lower-bound (>= iterations minimum))
+        (setf is-in-lower-bound T))
+      (if maximum
+        (setf is-in-upper-bound (<= iterations maximum))
+        (setf is-in-upper-bound T)))
+    (and is-in-lower-bound is-in-upper-bound)))
+
+(defun get-range-check-function (range-string)
+  (let ((range (parse-range range-string)))
+    #'(lambda (counter)
+        (are-iterations-in-range range counter))))
+
+;;; ----------------------------------------------------
+
+;; Parses a string of the arrangement
+;;   "a_1, ..., a_i, ..., a_n"
+;; with a_i: a positive integer number.
+;; 
+;; Notes:
+;;   - Whitespaces are ignored.
+;;   - The string must not be empty.
+;;   - Only integer numbers >= 0 are valid.
+;;   - Besides integer numbers >=0 (with optional positive sign "+")
+;;     and whitespaces, only commas are tolerated.
+;; 
+(defun parse-number-set (string)
+  (setf string (string-trim "=" string))
+  (labels ((parse-integer-in-subsequence (start-index end-index)
+             (let ((number (parse-integer
+                             (subseq string start-index
+                               (if end-index
+                                 end-index
+                                 (length string))))))
+              (if (>= number 0)
+                number
+                (error "Only integer numbers >= 0 are valid repetitions: ~s < 0."
+                        number)))))
+    (loop
+      for     start-index = 0 then (if end-index (1+ end-index) NIL)
+      for     end-index   = (if start-index
+                              (position #\, string :start start-index)
+                              NIL)
+      while   start-index
+      collect (parse-integer-in-subsequence start-index end-index))))
+
+(defun get-set-check-function (set-string)
+  (let ((number-set (parse-number-set set-string)))
+    #'(lambda (counter)
+        (member counter number-set :test #'=))))
+
+;;; ----------------------------------------------------
+
+;; Parses a function name in the pattern:
+;;   %:function-name:
+;; 
+;; The "function-name" is converted into upper-case letters.
+;; The respective function is expected to be of arity one:
+;;   lambda(counter) => generalized-boolean
+;; 
+(defun parse-user-function (string)
+  ;; (subseq string ...): Remove the "%:" portion from the start
+  ;;                      and    the ":"  portion from the end.
+  ;;                      => Yield: raw "function-name".
+  (let* ((function-name   (subseq string    2 (1- (length string))))
+         (function-symbol (read-from-string function-name))
+         (function-object (fdefinition      function-symbol)))
+    function-object))
+
+(defun get-user-check-function (string)
+  (parse-user-function string))
+
+;;; ----------------------------------------------------
+
+(defun get-iteration-check-function (range-string)
+  "Parses the RANGE-STRING and returns a unary function of signature
+     lambda(counter) => generalized-boolean
+   which is expected to return ``T'', iff the number of iterations
+   COUNTER is valid."
+  (let ((identifier (char range-string 0)))
+    (cond
+      ((char-equal identifier #\[) (get-range-check-function range-string))
+      ((char-equal identifier #\=) (get-set-check-function   range-string))
+      ((char-equal identifier #\%) (get-user-check-function  range-string))
+      (t                           (error "Invalid range identifier: ~s." identifier)))))
 
 ;;; ----------------------------------------------------
 
@@ -390,7 +942,25 @@
                              (resolve-label this)
                              (compile-tokens (list x))
                              (resolve-label else)))
-
+                       
+                       ;; ranged iterator
+                       (:range (let ((try   (make-label))
+                                     (done  (make-label))
+                                     (again (make-label)))
+                                 (let ((iteration-check-function (get-iteration-check-function y)))
+                                   (compile-op     :start-counter iteration-check-function)
+                                   
+                                   (resolve-label  again)
+                                   (compile-op     :split try done)
+                                   
+                                   (resolve-label  try)
+                                   (compile-tokens (list x))
+                                   (compile-op     :increase-counter)
+                                   (compile-op     :jump again)
+                                   
+                                   (resolve-label  done)
+                                   (compile-op     :check-counter))))
+                       
                        ;; Lua boundary
                        (:bounds (let ((try (make-label))
                                       (done (make-label))
@@ -410,6 +980,11 @@
                        ;; capture groups push, match, and pop
                        (:capture (progn
                                    (compile-op :push)
+                                   
+                                   ;; Named group? => "y" is non NIL.
+                                   (when y
+                                     (compile-op :name-group y))
+                                   
                                    (compile-tokens x)
                                    (compile-op :pop)))
 
@@ -436,28 +1011,120 @@
 
 ;;; ----------------------------------------------------
 
-(defstruct (re-thread (:constructor make-re-thread (pc sp groups stack)))
-  pc        ; program counter in compiled re instruction vector
-  sp        ; string pointer
-  groups    ; pushed capture groups (subseq)
-  stack)    ; pushed capture groups (sp)
+;; Repetition counter and inclusion check function for
+;; ranged quantifiers of the type
+;;   {[min,max]}
+;;   {=set-of-numbers}
+;;   {%:checking-function:}
+;; 
+(defstruct (re-counter
+  (:constructor   make-counter (iterations check-function))
+  (:conc-name     counter-))
+  (iterations     0)         ;; Increased on each iteration.
+  (check-function NIL))      ;; Checks the ITERATIONS for a match.
 
 ;;; ----------------------------------------------------
 
+(defun counter-increase (counter)
+  "Increased the re-counter COUNTER's number of iterations by one.
+   Returns the modified COUNTER."
+  (with-slots (iterations) counter
+    (incf iterations))
+  counter)
+
+;;; ----------------------------------------------------
+
+(defun counter-check (counter)
+  "Checks whether the COUNTER's number of iterations is a valid match
+   according to the COUNTER's checking function.
+   Returns:
+     T   - if the COUNTER's current value matches.
+     NIL - if the COUNTER's current value does not match."
+  (with-slots (iterations check-function) counter
+    (funcall check-function iterations)))
+
+;;; ----------------------------------------------------
+
+(defmethod print-object ((counter re-counter) stream)
+  (format stream "#<re-counter ~a>" (counter-iterations counter)))
+
+;;; ----------------------------------------------------
+
+(defstruct (re-thread (:constructor make-re-thread (pc sp groups stack counters)))
+  pc        ; program counter in compiled re instruction vector
+  sp        ; string pointer
+  groups    ; pushed capture groups (subseq)
+  stack     ; pushed capture groups (sp)
+  counters) ; list of ranged quantifiers counter, each item an re-counter instance.
+
+;;; ----------------------------------------------------
+
+;; Input:  GROUPS - List of findings as triple
+;;                    (start-index end-index group-name),
+;;                  ordered in reverse discovery sequence.
+;; Output: Vector of re-capture instances.
+(defun captures-from-groups (input-string groups)
+  "Creates and returns a vector of ``re-capture'' objects from the
+   INPUT-STRING and the GROUPS.
+   The GROUPS are expected as a list of triples, each such comprised of:
+     (start-index-in-INPUT end-index-in-INPUT group-name)
+   The group name may be NIL, in that case the captured group is
+   unnamed."
+  (let ((captures (make-array (length groups) :adjustable T :fill-pointer 0)))
+    (loop
+      for (start-index end-index group-name) in (reverse groups)
+      for substring = (subseq input-string start-index end-index)
+      do  (let ((capture (make-instance 're-capture
+                           :start-position start-index
+                           :end-position   end-index
+                           :substring      substring
+                           :name           group-name)))
+           (vector-push-extend capture captures)))
+    captures))
+
+;; Input:  CAPTURES - Vector of re-capture instances.
+;; Output: Hash-table mapping
+;;           group-name -> (vector indices-of-groups-with-this-group-name)
+(defun name-map-from-captures (captures)
+  "Creates and returns a hash table mapping of the captured group names
+   to the indices of the respective ``re-capture'' objects in the
+   CAPTURES.
+   CAPTURES is a vector of ``re-capture'' instances.
+   Example: An entry in the resulting hash table
+              'animal' -> (vector 4 7)
+            means that the ``re-capture'' instances in the CAPTURES
+            vector at the positions four and seven are associated with
+            the captured group name 'animal'."
+  (let ((name-map (make-hash-table :test #'equal)))
+    (loop
+      for capture     across captures
+      for group-name  =    (re-capture-name capture)
+      for group-index from 0
+      do  (let ((group-indices-for-name (gethash group-name name-map)))
+            (unless group-indices-for-name
+              (setf group-indices-for-name
+                (make-array 0 :adjustable T :fill-pointer 0)))
+            (vector-push-extend group-index group-indices-for-name)
+            (setf (gethash group-name name-map) group-indices-for-name)))
+    name-map))
+
 (defun match (s thread start offset)
   "Create a re-match from a thread that matched."
-  (with-slots (sp groups)
-      thread
-    (let ((cs (let (cs)
-                (do ((g (pop groups)
-                        (pop groups)))
-                    ((null g) cs)
-                  (push (subseq s (first g) (second g)) cs)))))
-      (make-instance 're-match
-                     :start-pos (+ start offset)
-                     :end-pos sp
-                     :groups cs
-                     :match (subseq s (+ start offset) sp)))))
+  (with-slots (sp groups) thread
+    (let* ((captures (captures-from-groups   s groups))
+           (name-map (name-map-from-captures captures)))
+      (let ((cs (let (cs)
+                  (do ((g (pop groups)
+                          (pop groups)))
+                      ((null g) cs)
+                    (push (subseq s (first g) (second g)) cs)))))
+        (make-instance 're-match
+                       :start-pos (+ start offset)
+                       :end-pos   sp
+                       :groups    cs
+                       :captures  captures
+                       :name-map  name-map
+                       :match     (subseq s (+ start offset) sp))))))
 
 ;;; ----------------------------------------------------
 
@@ -465,7 +1132,7 @@
   "Execute a regular expression program."
   (declare (optimize (safety 0) (debug 0) (speed 3)))
   (loop
-     with threads = (list (make-re-thread pc (+ start offset) nil nil))
+     with threads = (list (make-re-thread pc (+ start offset) nil nil nil))
 
      ;; get the next thread off the list
      for thread = (pop threads)
@@ -474,7 +1141,7 @@
      until (null thread)
 
      ;; evaluate the next thread, checking for a match
-     do (with-slots (pc sp groups stack)
+     do (with-slots (pc sp groups stack counters)
             thread
           (loop
              for (op x y) = (aref re pc)
@@ -512,18 +1179,46 @@
                      (:push    (let ((capture (list sp)))
                                  (push capture stack)
                                  (push capture groups)))
-
+                     
+                     ;; Named group?
+                     ;; => Extend current capture group by group name.
+                     (:name-group
+                               (progn
+                                 (rplacd (first groups) (list x))
+                                 (rplacd (first stack)  (list x))))
+                     
                      ;; pop a capture group
-                     (:pop     (rplacd (pop stack) (list sp)))
+                     (:pop     (let* ((group      (pop    stack))
+                                      (group-name (second group)))
+                                 (rplacd group (list sp group-name))))
 
                      ;; jump to an instruction
                      (:jump    (setf pc x))
 
                      ;; fork a thread
-                     (:split   (let ((b (make-re-thread y sp groups stack)))
+                     (:split   (let ((b (make-re-thread y sp groups stack counters)))
                                  (push b threads)
                                  (setf pc x)))
-
+                     
+                     ;; Start counting the number of iterations for
+                     ;; a ranged iterator.
+                     ;; "x" contains the range quantifier check function.
+                     (:start-counter
+                       (let ((new-counter (make-counter 0 x)))
+                         (push new-counter counters)))
+                     
+                     ;; Increase the number of iterations.
+                     (:increase-counter
+                       (counter-increase (first counters)))
+                     
+                     ;; Check whether the number of iterations matches
+                     ;; the range quantifier's bounds.
+                     (:check-counter
+                       (let ((is-in-range (counter-check (first counters))))
+                         (when is-in-range
+                           (pop counters))
+                         is-in-range))
+                     
                      ;; successfully matched, create and return
                      (:match   (return-from run
                                  (match s thread start offset))))))))
@@ -541,6 +1236,173 @@
 
 ;;; ----------------------------------------------------
 
+#|
+;; Convert
+;;   (vector re-capture-1 ... re-capture-N)
+;; into
+;;   hash-table: group-name-i -> substr-i
+;;               or
+;;               group-name-i -> (substr-i-1 ... substr-i-M)
+;; 
+(defun match-captures-to-map (captures)
+  (let ((name-group-table (make-hash-table :test #'equal)))
+    (labels (;; Convert the hash-table scalar value for the key
+             ;; GROUP-NAME into a one-element list: (list value),
+             ;; for further item appendage.
+             (entry-to-list (group-name)
+               (setf (gethash group-name name-group-table)
+                 (list (gethash group-name name-group-table)))
+               name-group-table)
+             (set-substring (group-name substring)
+               (setf (gethash group-name name-group-table)
+                     substring))
+             ;; Interpret the hash-table value for the GROUP-NAME as
+             ;; a list, and append the SUBSTRING to the list tail.
+             (add-substring (group-name substring)
+               (setf (gethash group-name name-group-table)
+                     (append (gethash group-name name-group-table)
+                             (list substring)))
+               name-group-table))
+      (loop for match across captures do
+        (let ((substring  (re-capture-substring match))
+              (group-name (re-capture-name      match)))
+          (cond
+            ((null group-name)  (add-substring "" substring))
+            (t                  (let ((matches-for-name (gethash group-name name-group-table)))
+                                  (if (null matches-for-name)
+                                    (set-substring group-name substring)
+                                    (progn
+                                      (unless (listp matches-for-name)
+                                        (entry-to-list group-name))
+                                      (add-substring group-name substring)))))))))
+    name-group-table))
+|#
+
+;;; ----------------------------------------------------
+
+(defun retrieve-set-of-captures (match set)
+  (cond
+    ((and (symbolp set) (eq set :all-groups))
+     (match-captures         match))
+    ((and (symbolp set) (eq set :unnamed-groups))
+     (map 'vector
+       #'(lambda (capture)
+           (not (re-capture-has-name capture)))
+       (match-captures match)))
+    ((and (symbolp set) (eq set :named-groups))
+     (map 'vector
+       #'(lambda (capture)
+           (re-capture-has-name capture))
+       (match-captures match)))
+    ((stringp set)
+     (match-captures-by-name match set))
+    (T
+     (error "Invalid SET: ~a."     set))))
+
+;;; ----------------------------------------------------
+
+(defun extract-components (captures component)
+  (case component
+    (:capture        captures)
+    (:substring      (map 'vector #'re-capture-substring      captures))
+    (:start-position (map 'vector #'re-capture-start-position captures))
+    (:end-position   (map 'vector #'re-capture-end-position   captures))
+    (:start-and-end-position
+                     (map 'vector
+                       #'(lambda (capture)
+                           (list (re-capture-start-position capture)
+                                 (re-capture-end-position   capture)))
+                       captures))
+    (:name           (map 'vector #'re-capture-name           captures))
+    (otherwise       (error "Invalid COMPONENT: ~a." component))))
+
+;;; ----------------------------------------------------
+
+(defun select-captures (captures selection default-value)
+  (cond
+    ((symbolp  selection)
+      (case selection
+        (:all   captures)
+        (:first (if (plusp (length captures))
+                  (aref captures 0)
+                  default-value))
+        (:last  (if (plusp (length captures))
+                  (aref captures (1- (length captures)))
+                  default-value))))
+    ((integerp selection)
+      (if (array-in-bounds-p captures selection)
+        (aref captures selection)
+        default-value))
+    (T (error "Invalid SELECTION: ~a." selection))))
+
+;;; ----------------------------------------------------
+
+(defun match-extract-data
+  (match
+   &key ;; Valid: {:all-groups, :named-groups, :unnamed-groups,
+        ;          group-name-string}.
+        (set       :all-groups)
+        ;; Valid: {:all, :first, :last, integer-index}.
+        (selection :all)
+        ;; Valid: {:capture, :substring, :start-position, :end-position,
+        ;;         :start-and-end-position, :name}.
+        (component :capture)
+        ;; Substitute value for lacuna of result.
+        (default    NIL))
+  "Extracts the desiderated captured groups' data from the MATCH.
+   Input:
+     SET       - Designates which subset of ``re-capture'' objects
+                 to retrieve from the MATCH.
+                 Valid options comprise:
+                   :all-groups     - Returns a vector containing all
+                                     groups of the MATCH.
+                                     This is the default.
+                   :named-groups   - Returns a vector containing only
+                                     named groups. Unnamed ones will be
+                                     discarded.
+                   :unnamed-groups - Returns a vector containing only
+                                     unnamed groups. Named ones will be
+                                     discarded.
+                   group-name      - A string designating the name of
+                                     the named group(s) to retrieve.
+                                     Regardless of the quantity of these ---
+                                     even if zero or one group with such
+                                     denomination is found --- a vector
+                                     of ``re-captures'' is returned.
+     SELECTION - As the selected SET yields a vector of captures,
+                 this parameter returns either the whole vector or a
+                 specified item thereof.
+                 Valid options are:
+                   :all   - The complete SET vector. This is the default.
+                   :first - The first group in the SET vector.
+                   :last  - The last group in the SET vector.
+                   index  - An non-negative integer designating the
+                            index of the group in the SET vector to
+                            retrieve.
+     COMPONENT - The information to extract from each captured group.
+                 May be one of these:
+                   :capture        - The whole ``re-capture'' object.
+                                     This is the default.
+                   :substring      - The substring captured by the group.
+                   :start-position - The start position in the input
+                                     where the group begins.
+                   :end-position   - The end position in the input
+                                     where the group ends.
+                   :start-and-end-position -
+                                     A list of two items in
+                                     this order:
+                                       (start-position end-position).
+                   :name           - The name of the group or, if it
+                                     is unnamed, the NIL value.
+     DEFAULT   - A substitute value to return if the specified group
+                 cannot be retrieved, for instance because of a
+                 nonexistent group name."
+  (let ((captures (retrieve-set-of-captures match set)))
+    (setf captures (extract-components captures component))
+    (select-captures captures selection default)))
+
+;;; ----------------------------------------------------
+
 (defmacro with-re-match ((match match-expr &key no-match) &body body)
   "Intern match symbols to execute a body."
   (let (($$ (intern "$$" *package*))
@@ -554,24 +1416,35 @@
         ($8 (intern "$8" *package*))
         ($9 (intern "$9" *package*))
         ($_ (intern "$_" *package*))
-        ($* (intern "$*" *package*)))
+        ($* (intern "$*" *package*))
+        
+        ($-> (intern "$->" *package*)))
     `(let ((,match ,match-expr))
        (if (null ,match)
            ,no-match
-         (let ((,$$ (match-string ,match))
-               (,$* (match-groups ,match)))
+         (let ((,$$  (match-string   ,match))
+               (,$*  (match-groups   ,match))
+               (,$<> (match-captures ,match)))
            (declare (ignorable ,$$ ,$*))
-           (symbol-macrolet ((,$1 (first ,$*))
-                             (,$2 (second ,$*))
-                             (,$3 (third ,$*))
-                             (,$4 (fourth ,$*))
-                             (,$5 (fifth ,$*))
-                             (,$6 (sixth ,$*))
-                             (,$7 (seventh ,$*))
-                             (,$8 (eighth ,$*))
-                             (,$9 (ninth ,$*))
-                             (,$_ (nthcdr 9 ,$*)))
-             (progn ,@body)))))))
+           
+           (labels ((,$-> (set &optional (selection :all) (component :capture) (default NIL))
+                          (match-extract-data ,match
+                            :set       set
+                            :selection selection
+                            :component component
+                            :default   default)))
+             
+             (symbol-macrolet ((,$1 (first    ,$*))
+                               (,$2 (second   ,$*))
+                               (,$3 (third    ,$*))
+                               (,$4 (fourth   ,$*))
+                               (,$5 (fifth    ,$*))
+                               (,$6 (sixth    ,$*))
+                               (,$7 (seventh  ,$*))
+                               (,$8 (eighth   ,$*))
+                               (,$9 (ninth    ,$*))
+                               (,$_ (nthcdr 9 ,$*)))
+               (progn ,@body))))))))
 
 ;;; ----------------------------------------------------
 

--- a/re.lisp
+++ b/re.lisp
@@ -1236,50 +1236,6 @@
 
 ;;; ----------------------------------------------------
 
-#|
-;; Convert
-;;   (vector re-capture-1 ... re-capture-N)
-;; into
-;;   hash-table: group-name-i -> substr-i
-;;               or
-;;               group-name-i -> (substr-i-1 ... substr-i-M)
-;; 
-(defun match-captures-to-map (captures)
-  (let ((name-group-table (make-hash-table :test #'equal)))
-    (labels (;; Convert the hash-table scalar value for the key
-             ;; GROUP-NAME into a one-element list: (list value),
-             ;; for further item appendage.
-             (entry-to-list (group-name)
-               (setf (gethash group-name name-group-table)
-                 (list (gethash group-name name-group-table)))
-               name-group-table)
-             (set-substring (group-name substring)
-               (setf (gethash group-name name-group-table)
-                     substring))
-             ;; Interpret the hash-table value for the GROUP-NAME as
-             ;; a list, and append the SUBSTRING to the list tail.
-             (add-substring (group-name substring)
-               (setf (gethash group-name name-group-table)
-                     (append (gethash group-name name-group-table)
-                             (list substring)))
-               name-group-table))
-      (loop for match across captures do
-        (let ((substring  (re-capture-substring match))
-              (group-name (re-capture-name      match)))
-          (cond
-            ((null group-name)  (add-substring "" substring))
-            (t                  (let ((matches-for-name (gethash group-name name-group-table)))
-                                  (if (null matches-for-name)
-                                    (set-substring group-name substring)
-                                    (progn
-                                      (unless (listp matches-for-name)
-                                        (entry-to-list group-name))
-                                      (add-substring group-name substring)))))))))
-    name-group-table))
-|#
-
-;;; ----------------------------------------------------
-
 (defun retrieve-set-of-captures (match set)
   (cond
     ((and (symbolp set) (eq set :all-groups))
@@ -1423,8 +1379,7 @@
        (if (null ,match)
            ,no-match
          (let ((,$$  (match-string   ,match))
-               (,$*  (match-groups   ,match))
-               (,$<> (match-captures ,match)))
+               (,$*  (match-groups   ,match)))
            (declare (ignorable ,$$ ,$*))
            
            (labels ((,$-> (set &optional (selection :all) (component :capture) (default NIL))


### PR DESCRIPTION
Added:
- Named captured groups, similar to those in Java and Perl. These follow the pattern "(!&lt;GROUP-NAME&gt;...)". Examples and elucidations will follow soon.
- Ranged quantifiers, similar to Java and Perl. These follow the pattern "{[min,max]}", "{=comma-separated-numbers}" and "{%:user-defined-checking-function:}". Examples and elucidations will follow soon.
- Implemented the means to configure and deactivate the above features to obviate compatibility issues with extant software using the "re" library. Examples and elucidations will follow soon.

NOTES: As mentioned above, these two new features might change the behavior of existing programs based on the "re" library, for instance by interpretation of the "{" character as ranged qualifier start marker.

Fixed:
- In a character set using the character pair "(?" only the "(" character is recognized, as the "?" is processed and lost by the ":group" parsing. Example: (match-re "[(?]" "?") accepts the input string "(", but does not match the input string "?".
